### PR TITLE
README needs extra pip install

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ pip install -U pip cmake cython==0.29.36 pydantic==1.10 numpy
 pip install -U gdown pydrive2 wget jupyter jupyterlab jupyterthemes ipython
 pip install -U sentencepiece transformers diffusers tokenizers datasets gradio==3.37 accelerate evaluate git+https://github.com/openai/CLIP.git
 pip install -U https://download.pytorch.org/whl/cu113/torch-1.12.0%2Bcu113-cp310-cp310-linux_x86_64.whl https://download.pytorch.org/whl/cu113/torchvision-0.13.0%2Bcu113-cp310-cp310-linux_x86_64.whl https://download.pytorch.org/whl/cu113/torchaudio-0.12.0%2Bcu113-cp310-cp310-linux_x86_64.whl
+pip install -U py-cpuinfo
 pip install -U deepspeed
 
 # git clone this repo


### PR DESCRIPTION
In the Requirements, there is an error when you go to `pip install -U deepspeed`

```

Collecting deepspeed
  Downloading deepspeed-0.13.1.tar.gz (1.3 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 1.3/1.3 MB 13.9 MB/s eta 0:00:00
  Preparing metadata (setup.py) ... error
  error: subprocess-exited-with-error
  
  × python setup.py egg_info did not run successfully.
  │ exit code: 1
  ╰─> [20 lines of output]
      Traceback (most recent call last):
        File "<string>", line 2, in <module>
        File "<pip-setuptools-caller>", line 34, in <module>
        File "/private/var/folders/7k/3dgz3xjn1z113r_zylqqnbj40000gp/T/pip-install-_5o_lpcw/deepspeed_45a05a4d68e740d8a4bb722973800f83/setup.py", line 38, in <module>
          from op_builder.all_ops import ALL_OPS
        File "/private/var/folders/7k/3dgz3xjn1z113r_zylqqnbj40000gp/T/pip-install-_5o_lpcw/deepspeed_45a05a4d68e740d8a4bb722973800f83/op_builder/all_ops.py", line 29, in <module>
          builder = get_accelerator().create_op_builder(member_name)
        File "/private/var/folders/7k/3dgz3xjn1z113r_zylqqnbj40000gp/T/pip-install-_5o_lpcw/deepspeed_45a05a4d68e740d8a4bb722973800f83/accelerator/mps_accelerator.py", line 234, in create_op_builder
          builder_class = self.get_op_builder(op_name)
        File "/private/var/folders/7k/3dgz3xjn1z113r_zylqqnbj40000gp/T/pip-install-_5o_lpcw/deepspeed_45a05a4d68e740d8a4bb722973800f83/accelerator/mps_accelerator.py", line 241, in get_op_builder
          from deepspeed.ops.op_builder.cpu import NotImplementedBuilder
        File "/private/var/folders/7k/3dgz3xjn1z113r_zylqqnbj40000gp/T/pip-install-_5o_lpcw/deepspeed_45a05a4d68e740d8a4bb722973800f83/deepspeed/__init__.py", line 21, in <module>
          from . import ops
        File "/private/var/folders/7k/3dgz3xjn1z113r_zylqqnbj40000gp/T/pip-install-_5o_lpcw/deepspeed_45a05a4d68e740d8a4bb722973800f83/deepspeed/ops/__init__.py", line 6, in <module>
          from . import adam
        File "/private/var/folders/7k/3dgz3xjn1z113r_zylqqnbj40000gp/T/pip-install-_5o_lpcw/deepspeed_45a05a4d68e740d8a4bb722973800f83/deepspeed/ops/adam/__init__.py", line 6, in <module>
          from .cpu_adam import DeepSpeedCPUAdam
        File "/private/var/folders/7k/3dgz3xjn1z113r_zylqqnbj40000gp/T/pip-install-_5o_lpcw/deepspeed_45a05a4d68e740d8a4bb722973800f83/deepspeed/ops/adam/cpu_adam.py", line 7, in <module>
          from cpuinfo import get_cpu_info
      ModuleNotFoundError: No module named 'cpuinfo'
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
error: metadata-generation-failed

× Encountered error while generating package metadata.
╰─> See above for output.

note: This is an issue with the package mentioned above, not pip.
hint: See above for details.
```

To solve this, I placed `pip install -U py-cpuinfo` above `deepspeed` which now results in a successful install.