### PR TITLE
docs: correct license file extension in contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,6 +6,6 @@ While we welcome new pull requests and issues please note that our response may 
 
 ## Before you get started
 
-By submitting a pull request, you represent that you have the right to license your contribution to Apple and the community, and agree by submitting the patch that your contributions are licensed under the [LICENSE](LICENSE).
+By submitting a pull request, you represent that you have the right to license your contribution to Apple and the community, and agree by submitting the patch that your contributions are licensed under the [LICENSE](LICENSE.txt).
 
 We ask that all community members read and observe our [Code of Conduct](CODE_OF_CONDUCT.md).


### PR DESCRIPTION
Just a quick PR to add the correct license file extension in the contributing guide.

Currently, clicking on it brings you to a 404:

<img width="1130" alt="ml-mgie" src="https://github.com/apple/ml-mgie/assets/13087421/439531c5-eaaf-4732-b9ca-41960d026fb1">
